### PR TITLE
Fix 404 on Vercel by exporting serverless handler

### DIFF
--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,0 +1,22 @@
+import { NestFactory, Reflector } from '@nestjs/core';
+import { ExpressAdapter } from '@nestjs/platform-express';
+import * as express from 'express';
+import { AppModule } from './app.module';
+import { LoggingInterceptor } from './interceptors/logging.interceptor';
+
+const expressApp = express();
+let initialized = false;
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule, new ExpressAdapter(expressApp));
+  app.useGlobalInterceptors(new LoggingInterceptor(new Reflector()));
+  await app.init();
+  initialized = true;
+}
+
+export default async function handler(req: express.Request, res: express.Response) {
+  if (!initialized) {
+    await bootstrap();
+  }
+  expressApp(req, res);
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "version": 2,
-  "builds": [{ "src": "dist/main.js", "use": "@vercel/node" }],
-  "routes": [{ "src": "/(.*)", "dest": "dist/main.js" }]
+  "builds": [{ "src": "dist/lambda.js", "use": "@vercel/node" }],
+  "routes": [{ "src": "/(.*)", "dest": "dist/lambda.js" }]
 }


### PR DESCRIPTION
## Summary
- implement `src/lambda.ts` to initialize Nest app and handle requests
- configure Vercel to use the new handler

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_684298f0789c832daffb121ab5f47a45