### PR TITLE
Fix Vercel lambda entrypoint

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,14 +2,14 @@
   "version": 2,
   "builds": [
     {
-      "src": "dist/main.js",
+      "src": "dist/lambda.js",
       "use": "@vercel/node"
     }
   ],
   "routes": [
     {
       "src": "/(.*)",
-      "dest": "dist/main.js",
+      "dest": "dist/lambda.js",
       "methods": ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
     }
   ]


### PR DESCRIPTION
## Summary
- fix Vercel config to call the lambda handler

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68429ee1507c832db97e94ea3c2a4979